### PR TITLE
Direct peek

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -6250,7 +6250,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -6264,6 +6264,32 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="direct_peek_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Peek window instead of displaying a preview</property>
+                            <property name="use_markup">True</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="direct_peek_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
                             <property name="top_attach">1</property>
                           </packing>
                         </child>

--- a/appIcons.js
+++ b/appIcons.js
@@ -285,10 +285,20 @@ var taskbarAppIcon = Utils.defineClass({
             return;
         }
 
+        var useDirectPeek = Me.settings.get_boolean('direct-peek');
+
         if (this.actor.hover) {
-            this._previewMenu.requestOpen(this);
+            if (!useDirectPeek) {
+                this._previewMenu.requestOpen(this);
+            } else {
+                this._previewMenu.requestPeek(this.window);
+            }
         } else {
-            this._previewMenu.requestClose();
+            if (!useDirectPeek) {
+                this._previewMenu.requestClose();
+            } else {
+                this._previewMenu.requestEndPeek();
+            }
         }
     },
 

--- a/prefs.js
+++ b/prefs.js
@@ -1118,6 +1118,11 @@ const Settings = new Lang.Class({
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
 
+        this._settings.bind('direct-peek',
+                            this._builder.get_object('direct_peek_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+
         this._settings.bind('show-tooltip',
                             this._builder.get_object('show_tooltip_switch'),
                             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -432,6 +432,11 @@
       <summary>Show window preview</summary>
       <description>Show preview of running window on hover of app icon</description>
     </key>
+    <key type="b" name="direct-peek">
+      <default>false</default>
+      <summary>Peek window instead of displaying a preview</summary>
+      <description>Peek running window on hover of app icon</description>
+    </key>
     <key type="b" name="show-tooltip">
       <default>true</default>
       <summary>Show tooltip</summary>

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -41,6 +41,7 @@ const T1 = 'openMenuTimeout';
 const T2 = 'closeMenuTimeout';
 const T3 = 'peekTimeout';
 const T4 = 'ensureVisibleTimeout';
+const T5 = 'endPeekTimeout';
 
 const MAX_TRANSLATION = 40;
 const HEADER_HEIGHT = 38;
@@ -260,6 +261,7 @@ var PreviewMenu = Utils.defineClass({
 
     requestPeek: function(window) {
         this._timeoutsHandler.remove(T3);
+        this._timeoutsHandler.remove(T5);
 
         if (Me.settings.get_boolean('peek-mode')) {
             if (this.peekInitialWorkspaceIndex < 0) {
@@ -268,6 +270,11 @@ var PreviewMenu = Utils.defineClass({
                 this._peek(window);
             }
         }
+    },
+
+    requestEndPeek: function() {
+        this._timeoutsHandler.remove(T5);
+        this._timeoutsHandler.add([T5, Me.settings.get_int('leave-timeout'), () => this._endPeek()]);
     },
 
     endPeekHere: function() {


### PR DESCRIPTION
Direct peek feature
The user can hover an app to peek. It allows for a faster window preview.

![image](https://user-images.githubusercontent.com/793712/91043543-aa098200-e60b-11ea-90bf-41449ea858f5.png)

Here's a recording of this feature
https://youtu.be/oiQHX8g53u0

